### PR TITLE
Remove unnecessary Newtonsoft JSON dependency

### DIFF
--- a/HakosRoof/Driver.cs
+++ b/HakosRoof/Driver.cs
@@ -42,7 +42,6 @@ using System.Web;
 using System.Diagnostics;
 using System.Text;
 using RestSharp;
-using Newtonsoft.Json;
 
 namespace ASCOM.HakosRoof
 {
@@ -839,9 +838,9 @@ namespace ASCOM.HakosRoof
 
             // execute the request
             //IRestResponse<RestCallResult> response = client.Execute<RestCallResult>(requestLocal);
-            IRestResponse response = client.Execute(requestLocal);
+            var response = client.Execute<RestCallResult>(requestLocal);
             // var content = response.Content; // raw content as string
-            var JSONObj = JsonConvert.DeserializeObject<RestCallResult>(response.Content);
+            var JSONObj = response.Data;
 
             if  (JSONObj.msg=="invalid key")
             {

--- a/HakosRoof/HakosRoof.csproj
+++ b/HakosRoof/HakosRoof.csproj
@@ -72,9 +72,6 @@
     <Reference Include="log4net, Version=2.0.14.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.14\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="RestSharp, Version=106.15.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.15.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
@@ -89,9 +86,6 @@
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Net.Http, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Http.4.3.3\lib\net46\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />

--- a/HakosRoof/packages.config
+++ b/HakosRoof/packages.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.14" targetFramework="net46" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net46" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net46" />
   <package id="RestSharp" version="106.15.0" targetFramework="net46" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net46" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net46" />


### PR DESCRIPTION
Hi,

I'm Stefan Berg, the maintainer of N.I.N.A. - Nighttime Imaging 'N' Astronomy.
With the recent migration of N.I.N.A. to .NET 8 there have been some issues with compatibility of drivers.
Your Dome Driver currently has one of these issues due to some dependency chain of Newtonsoft.JSON that leads to a collision. I am unsure how to resolve this problem when keeping this library, however your usage of the library is very light and can even be omitted with the included RestSharp client, as it does handle simple deserialization cases already.

I've adapted your code and it loads fine in N.I.N.A. - I couldn't test the actual dome operation though with this change, but it should work.

Best Regards,
Stefan